### PR TITLE
Change opcode impl hook method

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -49,9 +49,10 @@ int main(int argc, char **argv)
     assemble_from_file(env, argv[1]);
 
     vm_add_inst(env, (vm_inst){.opcode = OP_HALT});
-    vm_hook_inst(env, OP_PRINT, print_impl);
-    vm_hook_inst(env, OP_ADD, add_impl);
-    vm_hook_inst(env, OP_SUB, sub_impl);
+    vm_hook_opcode_impl(env, OP_PRINT, print_impl);
+    vm_hook_opcode_impl(env, OP_ADD, add_impl);
+    vm_hook_opcode_impl(env, OP_SUB, sub_impl);
+
 
     vm_run(env);
 

--- a/vm.h
+++ b/vm.h
@@ -24,8 +24,12 @@ typedef struct {
     vm_operand op1;
     vm_operand op2;
     int result;
-    vm_handler handler;
 } vm_inst;
+
+typedef struct {
+    int opcode;
+    vm_handler handler;
+} vm_opcode_impl;
 
 #define VM_T(_op) _op->type
 #define VM_INT(_op) _op->value.vint
@@ -40,7 +44,7 @@ void vm_free(vm_env *);
 
 size_t vm_add_const(vm_env *, int, void *);
 size_t vm_add_inst(vm_env *, vm_inst);
-void vm_hook_inst(vm_env *, int, vm_handler);
+void vm_hook_opcode_impl(vm_env *, int, vm_handler);
 
 void vm_run(vm_env *env);
 


### PR DESCRIPTION
Original opcode impl hook is hooked on each instruction,
this design is inefficient when hooking impl and used more memory
for each instruction.

Now seperate opcode impl from each instruction, to a opcode_impl
array, which made hooking stage much faster.

Relate to #1
