### PR TITLE
Refactor opcode with eval loop

### DIFF
--- a/as.c
+++ b/as.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "vm.h"
+#include "opcode.h"
 
 struct instruction {
     const char *name;

--- a/driver.c
+++ b/driver.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 #include "vm.h"
+#include "opcode.h"
 
 #define UNIMPL                                       \
     do {                                             \

--- a/opcode.h
+++ b/opcode.h
@@ -1,0 +1,10 @@
+#ifndef OPCODE_H
+#define OPCODE_H
+
+#define OP_ADD 1
+#define OP_SUB 2
+#define OP_PRINT 3
+#define OP_JMP 4
+#define OP_HALT 255
+
+#endif /* OPCODE_H */

--- a/vm.h
+++ b/vm.h
@@ -34,9 +34,6 @@ typedef struct {
 #define VM_T(_op) _op->type
 #define VM_INT(_op) _op->value.vint
 
-/* opcode listing */
-enum { OP_ADD, OP_SUB, OP_PRINT, OP_JMP, OP_HALT };
-
 typedef struct __vm_env vm_env;
 
 vm_env *vm_new();


### PR DESCRIPTION
Remove opcode `labels`, using `opcode.h` to manage exist opcode.
Refactor VM eval loop for new opcode method.