### PR TITLE
Rearrange opcode for default halt in vm_inst

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -48,7 +48,6 @@ int main(int argc, char **argv)
 
     assemble_from_file(env, argv[1]);
 
-    vm_add_inst(env, (vm_inst){.opcode = OP_HALT});
     vm_hook_opcode_impl(env, OP_PRINT, print_impl);
     vm_hook_opcode_impl(env, OP_ADD, add_impl);
     vm_hook_opcode_impl(env, OP_SUB, sub_impl);

--- a/vm.c
+++ b/vm.c
@@ -70,7 +70,7 @@ typedef struct __vm_env {
     int temps_count;
 } vm_env;
 
-#define OP_LABELS &&OP_ADD, &&OP_SUB, &&OP_PRINT, &&OP_JMP, &&OP_HALT
+#define OP_LABELS &&OP_HALT, &&OP_ADD, &&OP_SUB, &&OP_PRINT, &&OP_JMP
 
 vm_env *vm_new()
 {

--- a/vm.h
+++ b/vm.h
@@ -35,7 +35,7 @@ typedef struct {
 #define VM_INT(_op) _op->value.vint
 
 /* opcode listing */
-enum { OP_ADD, OP_SUB, OP_PRINT, OP_JMP, OP_HALT };
+enum { OP_HALT, OP_ADD, OP_SUB, OP_PRINT, OP_JMP };
 
 typedef struct __vm_env vm_env;
 


### PR DESCRIPTION
When `vm_new` getting a new `vm_env`, it will reset memory, propose to rearrange opcode for `OP_HALT` to `0`, then we will no need for adding trailing halt instruction in runtime for each run.